### PR TITLE
Added make target for evaluate; removed redundant prefetch in mjsynth.y

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,6 @@ monitor:
 
 test:
 	cd src ; python test.py # use --help for options
+
+evaluate:
+	cd src ; python evaluate.py # use --help for options

--- a/src/mjsynth.py
+++ b/src/mjsynth.py
@@ -60,7 +60,8 @@ def get_dataset( args ):
                                        num_parallel_reads=num_threads,
                                        buffer_size=capacity )
 
-    return dataset.prefetch( buffer_sz )
+    return dataset
+
 
 def preprocess_fn( data ):
     """Parse the elements of the dataset"""


### PR DESCRIPTION
`make train` didn't work since `buffer_sz` was undefined in `mjsynth.py`